### PR TITLE
Change deployer mappings to public access

### DIFF
--- a/contracts/DeployerProxy.sol
+++ b/contracts/DeployerProxy.sol
@@ -32,7 +32,7 @@ contract DeployerProxy is IDeployerProxy, InjectorContextHolder {
         address deployer;
     }
 
-    mapping(address => Deployer) private _contractDeployers;
+    mapping(address => Deployer) _contractDeployers;
     mapping(address => SmartContract) private _smartContracts;
 
     constructor(bytes memory constructorParams) InjectorContextHolder(constructorParams) {


### PR DESCRIPTION
Modify a field to public access, which would be able to read it from storage in `evm` for faster querying.